### PR TITLE
Django Filters v3.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,22 @@ jobs:
         python-version:
           # Note: Use quotes to avoid float cast - especially important if the
           # version number ends with 0!
-          - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
-      - name: Clone Repo
+      - name: Clone repo
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
+          # https://github.com/actions/setup-python#caching-packages-dependencies
+          cache: pip
           python-version: ${{ matrix.python-version }}
-      - name: Install Dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install .
-      - name: Run Tests
+      - name: Run tests
         run: python manage.py test

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 .. image:: https://github.com/todofixthis/filters-django/actions/workflows/build.yml/badge.svg
    :target: https://github.com/todofixthis/filters-django/actions/workflows/build.yml
 .. image:: https://readthedocs.org/projects/filters/badge/?version=latest
-   :target: http://filters.readthedocs.io/
+   :target: https://filters.readthedocs.io/en/latest/extension_filters.html#django-filters
 
 Django Filters
 ==============
-Adds filters for for Django-specific features, including:
+Adds `filters`_ for for Django-specific features, including:
 
 - ``filters.ext.Model``: Search for a DB model instance matching the incoming
   value.
@@ -15,9 +15,9 @@ Requirements
 ------------
 Django Filters is known to be compatible with the following Python versions:
 
+- 3.12
 - 3.11
 - 3.10
-- 3.9
 
 Only Django v4.x is supported.
 
@@ -28,8 +28,8 @@ Only Django v4.x is supported.
    and/or Django not listed here — there just won't be any test coverage to
    prove it 😇
 
-If you encounter any issues, please report them on our `Bug Tracker`_, and be
-sure to indicate which version of Django you are using.
+If you encounter any issues, please report them on the project's `Bug Tracker`_,
+and be sure to indicate which version of Django you are using.
 
 Installation
 ------------
@@ -133,8 +133,9 @@ Steps to build releases are based on `Packaging Python Projects Tutorial`_
 #. Attach the build artefacts to the release.
 #. Click ``Publish release``.
 
-.. _Bug Tracker: https://github.com/eflglobal/filters-django/issues
+.. _Bug Tracker: https://github.com/todofixthis/filters-django/issues
 .. _Create a PyPI API token: https://pypi.org/manage/account/token/
+.. _filters: http://filters.readthedocs.io/
 .. _Filters library: https://pypi.python.org/pypi/phx-filters
 .. _Packaging Python Projects Tutorial: https://packaging.python.org/en/latest/tutorials/packaging-projects/
 .. _phx-filters repo: https://github.com/todofixthis/filters/blob/develop/docs/extension_filters.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 
 [project]
 name = "phx-filters-django"
-version = "3.0.1"
+version = "3.1.0"
 description = "Extends phx-filters, adding filters useful for Django applications."
 readme = "README.rst"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 license = { file = "LICENCE.txt" }
 authors = [
     { email = "Phoenix Zerin <phx@phx.nz>" }
@@ -23,15 +23,15 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.9",
     "Topic :: Software Development :: Libraries :: Python Modules",
     'Topic :: Text Processing :: Filters',
 ]
 
 dependencies = [
-    'phx-filters >= 3.0',
+    'phx-filters >= 3.4.0',
     'Django >= 4.0'
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{11,10,9}
+envlist = py3{12,11,10}
 
 [testenv]
 commands = python manage.py test


### PR DESCRIPTION
⚠️ This release drops support for Python 3.9 ⚠️

* Added support for Python 3.12, dropped support for Python 3.9.
* Minor documentation cleanup.