### PR TITLE
Release v3.3.0

### DIFF
--- a/.agents/skills/writing-adrs/SKILL.md
+++ b/.agents/skills/writing-adrs/SKILL.md
@@ -74,6 +74,11 @@ What follows — positive and negative.
 - **Number sequentially** — never reuse or renumber
 - **Supersede, don't edit** — new ADR for changed decisions; mark the old one superseded
 - **Keep it concise** — enough to reconstruct the reasoning, not a thesis
+- **Each section has a distinct job — don't let them overlap:**
+  - _Context_ — the problem and forces; stop before proposing any remedy
+  - _Options_ — approaches and trade-offs; don't restate what Context already said
+  - _Decision_ — why this option over others; don't re-describe the chosen option (Options already did that)
+  - _Consequences_ — what changes or must be managed downstream; not a restatement of the accepted option's pros/cons
 
 ## Supersession Workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dev = [
 
 [project]
 name = "phx-filters-django"
-version = "3.2.0"
+version = "3.3.0"
 description = "Extends phx-filters, adding filters useful for Django applications."
 readme = "README.rst"
 requires-python = ">= 3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 
 dependencies = [
     'phx-filters >= 3.4.0',
-    'Django >= 4.0'
+    'Django >= 4.2'
 ]
 
 # https://filters.readthedocs.io/en/latest/extensions.html#registering-your-filters
@@ -81,6 +81,7 @@ testpaths = ["test"]
 env_list = ["py312", "py313", "py314"]
 
 [tool.tox.env_run_base]
+allowlist_externals = ["pytest"]
 commands = [["pytest"]]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -425,7 +425,7 @@ wheels = [
 
 [[package]]
 name = "phx-filters-django"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },

--- a/uv.lock
+++ b/uv.lock
@@ -446,7 +446,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0" },
+    { name = "django", specifier = ">=4.2" },
     { name = "phx-filters", specifier = ">=3.4.0" },
 ]
 


### PR DESCRIPTION
# Django Filters v3.3.0
Raises the minimum supported Django version to the current LTS.

> [!WARNING]
> **Breaking changes**
> - Minimum Django version raised from 4.0 to 4.2
>   - Upgrade to Django 4.2 or later before upgrading this package
>   - You'll know you need to migrate if you see installation errors or
>     `PackageNotFoundError` when pip resolves dependencies
